### PR TITLE
Updates for changes to the metadata post-processor

### DIFF
--- a/client/go.mod
+++ b/client/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require github.com/google/uuid v1.6.0
 
 require (
-	github.com/pennsieve/processor-post-metadata/client v0.0.0-20241017161214-7ed76902fd93
+	github.com/pennsieve/processor-post-metadata/client v0.0.1
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/client/go.sum
+++ b/client/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/pennsieve/processor-post-metadata/client v0.0.0-20241017161214-7ed76902fd93 h1:shn0uRff454SokB0mUQt4nXgkm/3EQx3aA/OnhmWWrI=
-github.com/pennsieve/processor-post-metadata/client v0.0.0-20241017161214-7ed76902fd93/go.mod h1:zX++u/1ryjYTHccxi1xxyiBTM9v1ddsG6MaDhIVF3x0=
+github.com/pennsieve/processor-post-metadata/client v0.0.1 h1:GPpKnFwF4dbRfERgJ6tk5dtnnAI7lEbKdEjZsw6dvjA=
+github.com/pennsieve/processor-post-metadata/client v0.0.1/go.mod h1:RuD2gaFQsig2Ki+DbJZAN4DmQ37QIvJ8peNl0NOPHo0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/client/metadatatest/contributor.go
+++ b/client/metadatatest/contributor.go
@@ -42,3 +42,10 @@ func (b *ContributorBuilder) WithDegree() *ContributorBuilder {
 	b.c.Degree = uuid.NewString()
 	return b
 }
+
+func NewSavedContributor(contributor metadata.Contributor) metadata.SavedContributor {
+	return metadata.SavedContributor{
+		PennsieveID: NewPennsieveInstanceID(),
+		Contributor: contributor,
+	}
+}

--- a/client/metadatatest/proxy.go
+++ b/client/metadatatest/proxy.go
@@ -32,9 +32,9 @@ func (b *ProxyBuilder) Build(modelName string) metadata.Proxy {
 		PackageNodeID: "",
 	}
 	if b.entityID == nil {
-		proxy.EntityID = NewExternalInstanceID()
+		proxy.TargetExternalID = NewExternalInstanceID()
 	} else {
-		proxy.EntityID = *b.entityID
+		proxy.TargetExternalID = *b.entityID
 	}
 	if b.packageNodeID == nil {
 		proxy.PackageNodeID = NewCollectionNodeID()

--- a/client/models/metadata/contributor.go
+++ b/client/models/metadata/contributor.go
@@ -1,5 +1,7 @@
 package metadata
 
+import changesetmodels "github.com/pennsieve/processor-post-metadata/client/models"
+
 const ContributorModelName = "contributor"
 const ContributorDisplayName = "Contributor"
 
@@ -19,4 +21,13 @@ type Contributor struct {
 	Degree        string `json:"degree,omitempty"`
 	ORCID         string `json:"orcid,omitempty"`
 	NodeID        string `json:"node_id,omitempty"`
+}
+
+type SavedContributor struct {
+	PennsieveID changesetmodels.PennsieveInstanceID `json:"-"`
+	Contributor
+}
+
+func (s SavedContributor) GetPennsieveID() changesetmodels.PennsieveInstanceID {
+	return s.PennsieveID
 }

--- a/client/models/metadata/dataset_metadata.go
+++ b/client/models/metadata/dataset_metadata.go
@@ -44,7 +44,7 @@ func (s DatasetMetadata) ContributorsHash() (string, error) {
 }
 
 type SavedDatasetMetadata struct {
-	Contributors   []Contributor
+	Contributors   []SavedContributor
 	Subjects       []SavedSubject
 	Samples        []SavedSample
 	SampleSubjects []SavedSampleSubject

--- a/client/models/metadata/proxies.go
+++ b/client/models/metadata/proxies.go
@@ -8,9 +8,9 @@ import (
 type ProxyKey struct {
 	// ModelName is the name of the model of this proxy's record
 	ModelName string `json:"model_name"`
-	// EntityID is the external ID of the record that is linked to the given PackageNodeID
+	// TargetExternalID is the external ID of the record that is linked to the given PackageNodeID
 	// So probably either a Subject or Sample ID
-	EntityID changesetmodels.ExternalInstanceID `json:"entity_id"`
+	TargetExternalID changesetmodels.ExternalInstanceID `json:"entity_id"`
 }
 
 type Proxy struct {
@@ -19,7 +19,7 @@ type Proxy struct {
 }
 
 func (p Proxy) ExternalID() changesetmodels.ExternalInstanceID {
-	return changesetmodels.ExternalInstanceID(fmt.Sprintf("%s::%s::%s", p.ModelName, p.EntityID, p.PackageNodeID))
+	return changesetmodels.ExternalInstanceID(fmt.Sprintf("%s::%s::%s", p.ModelName, p.TargetExternalID, p.PackageNodeID))
 }
 
 type SavedProxy struct {

--- a/service/go.mod
+++ b/service/go.mod
@@ -6,8 +6,8 @@ replace github.com/pennsieve/ttl-sync-processor/client => ./../client
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/pennsieve/processor-post-metadata/client v0.0.0-20241028032242-bf767092d40e
-	github.com/pennsieve/processor-pre-metadata/client v0.0.1-0.20241022200351-e38914034b3d
+	github.com/pennsieve/processor-post-metadata/client v0.0.1
+	github.com/pennsieve/processor-pre-metadata/client v0.0.1
 	github.com/pennsieve/ttl-sync-processor/client v0.0.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/service/go.mod
+++ b/service/go.mod
@@ -6,8 +6,8 @@ replace github.com/pennsieve/ttl-sync-processor/client => ./../client
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/pennsieve/processor-post-metadata/client v0.0.0-20241024191615-2602d32907f4
-	github.com/pennsieve/processor-pre-metadata/client v0.0.0
+	github.com/pennsieve/processor-post-metadata/client v0.0.0-20241028032242-bf767092d40e
+	github.com/pennsieve/processor-pre-metadata/client v0.0.1-0.20241022200351-e38914034b3d
 	github.com/pennsieve/ttl-sync-processor/client v0.0.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/service/go.mod
+++ b/service/go.mod
@@ -6,8 +6,8 @@ replace github.com/pennsieve/ttl-sync-processor/client => ./../client
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/pennsieve/processor-post-metadata/client v0.0.0-20241017161214-7ed76902fd93
-	github.com/pennsieve/processor-pre-metadata/client v0.0.0-20241015190912-3e004748369b
+	github.com/pennsieve/processor-post-metadata/client v0.0.0-20241024191615-2602d32907f4
+	github.com/pennsieve/processor-pre-metadata/client v0.0.0
 	github.com/pennsieve/ttl-sync-processor/client v0.0.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/service/go.sum
+++ b/service/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/pennsieve/processor-post-metadata/client v0.0.0-20241017161214-7ed76902fd93 h1:shn0uRff454SokB0mUQt4nXgkm/3EQx3aA/OnhmWWrI=
-github.com/pennsieve/processor-post-metadata/client v0.0.0-20241017161214-7ed76902fd93/go.mod h1:zX++u/1ryjYTHccxi1xxyiBTM9v1ddsG6MaDhIVF3x0=
-github.com/pennsieve/processor-pre-metadata/client v0.0.0-20241015190912-3e004748369b h1:Gct/J1FVYjsRWniZtf5EZ2cAjT8uuRcQfL0au+7QpqI=
-github.com/pennsieve/processor-pre-metadata/client v0.0.0-20241015190912-3e004748369b/go.mod h1:2TzJ5tqUMbEWi+cKeotjKK/3mvX6d0Jq4ZdLjwMfjWw=
+github.com/pennsieve/processor-post-metadata/client v0.0.0-20241024191615-2602d32907f4 h1:/rcekElqJ1Wt2Lkgf30CdvqGNhDdpYx+R8TAq/MR6YU=
+github.com/pennsieve/processor-post-metadata/client v0.0.0-20241024191615-2602d32907f4/go.mod h1:rNqrFwqZzr3yDGKfZ2+LquD8pN431kIHSVc/t75kzi0=
+github.com/pennsieve/processor-pre-metadata/client v0.0.0 h1:JwXIbD06eLAxinrtedwJZ5HLXl1EiITuZhNSUZzYGfc=
+github.com/pennsieve/processor-pre-metadata/client v0.0.0/go.mod h1:2TzJ5tqUMbEWi+cKeotjKK/3mvX6d0Jq4ZdLjwMfjWw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/service/go.sum
+++ b/service/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/pennsieve/processor-post-metadata/client v0.0.0-20241024191615-2602d32907f4 h1:/rcekElqJ1Wt2Lkgf30CdvqGNhDdpYx+R8TAq/MR6YU=
-github.com/pennsieve/processor-post-metadata/client v0.0.0-20241024191615-2602d32907f4/go.mod h1:rNqrFwqZzr3yDGKfZ2+LquD8pN431kIHSVc/t75kzi0=
-github.com/pennsieve/processor-pre-metadata/client v0.0.0 h1:JwXIbD06eLAxinrtedwJZ5HLXl1EiITuZhNSUZzYGfc=
-github.com/pennsieve/processor-pre-metadata/client v0.0.0/go.mod h1:2TzJ5tqUMbEWi+cKeotjKK/3mvX6d0Jq4ZdLjwMfjWw=
+github.com/pennsieve/processor-post-metadata/client v0.0.0-20241028032242-bf767092d40e h1:UvNu2aEoMH3kk52B43sO1LMixNny/p0JNW/R4UEDLeI=
+github.com/pennsieve/processor-post-metadata/client v0.0.0-20241028032242-bf767092d40e/go.mod h1:rNqrFwqZzr3yDGKfZ2+LquD8pN431kIHSVc/t75kzi0=
+github.com/pennsieve/processor-pre-metadata/client v0.0.1-0.20241022200351-e38914034b3d h1:ySNiLiYh2FLNIsnfblSCPFEgaSJP+8xc+1HX2lkMgBQ=
+github.com/pennsieve/processor-pre-metadata/client v0.0.1-0.20241022200351-e38914034b3d/go.mod h1:2TzJ5tqUMbEWi+cKeotjKK/3mvX6d0Jq4ZdLjwMfjWw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/service/go.sum
+++ b/service/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/pennsieve/processor-post-metadata/client v0.0.0-20241028032242-bf767092d40e h1:UvNu2aEoMH3kk52B43sO1LMixNny/p0JNW/R4UEDLeI=
-github.com/pennsieve/processor-post-metadata/client v0.0.0-20241028032242-bf767092d40e/go.mod h1:rNqrFwqZzr3yDGKfZ2+LquD8pN431kIHSVc/t75kzi0=
-github.com/pennsieve/processor-pre-metadata/client v0.0.1-0.20241022200351-e38914034b3d h1:ySNiLiYh2FLNIsnfblSCPFEgaSJP+8xc+1HX2lkMgBQ=
-github.com/pennsieve/processor-pre-metadata/client v0.0.1-0.20241022200351-e38914034b3d/go.mod h1:2TzJ5tqUMbEWi+cKeotjKK/3mvX6d0Jq4ZdLjwMfjWw=
+github.com/pennsieve/processor-post-metadata/client v0.0.1 h1:GPpKnFwF4dbRfERgJ6tk5dtnnAI7lEbKdEjZsw6dvjA=
+github.com/pennsieve/processor-post-metadata/client v0.0.1/go.mod h1:RuD2gaFQsig2Ki+DbJZAN4DmQ37QIvJ8peNl0NOPHo0=
+github.com/pennsieve/processor-pre-metadata/client v0.0.1 h1:5Jlp1+hXTRhoKx5+vixetIHc7nzgxQTauo1ajj/wV1c=
+github.com/pennsieve/processor-pre-metadata/client v0.0.1/go.mod h1:2TzJ5tqUMbEWi+cKeotjKK/3mvX6d0Jq4ZdLjwMfjWw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=

--- a/service/mappings/fromcuration/proxies.go
+++ b/service/mappings/fromcuration/proxies.go
@@ -69,8 +69,8 @@ func mapProxiesOfType[JOIN ~string](modelName string, dirRecords []curation.Reco
 			}
 			proxies = append(proxies, metadata.Proxy{
 				ProxyKey: metadata.ProxyKey{
-					ModelName: modelName,
-					EntityID:  curationObject.ExternalID(),
+					ModelName:        modelName,
+					TargetExternalID: curationObject.ExternalID(),
 				},
 				PackageNodeID: nodeID,
 			})

--- a/service/mappings/fromcuration/proxies_test.go
+++ b/service/mappings/fromcuration/proxies_test.go
@@ -27,23 +27,23 @@ func TestMapProxies(t *testing.T) {
 	assert.Contains(t, proxies, metadata.Proxy{
 		PackageNodeID: "N:collection:57e23ec5-824f-4690-b615-83dbd5e4d626",
 		ProxyKey: metadata.ProxyKey{
-			ModelName: metadata.SampleModelName,
-			EntityID:  "09d2a327-be38-403a-884d-a4d1d98b732c",
+			ModelName:        metadata.SampleModelName,
+			TargetExternalID: "09d2a327-be38-403a-884d-a4d1d98b732c",
 		},
 	})
 
 	assert.Contains(t, proxies, metadata.Proxy{
 		PackageNodeID: "N:collection:dfca46a1-ceba-44f5-a462-4ec9d61b6a5f",
 		ProxyKey: metadata.ProxyKey{
-			ModelName: metadata.SampleModelName,
-			EntityID:  "09d2a327-be38-403a-884d-a4d1d98b732c",
+			ModelName:        metadata.SampleModelName,
+			TargetExternalID: "09d2a327-be38-403a-884d-a4d1d98b732c",
 		},
 	})
 
 	assert.Contains(t, proxies, metadata.Proxy{
 		ProxyKey: metadata.ProxyKey{
-			ModelName: metadata.SubjectModelName,
-			EntityID:  "f1027e6e-17cf-45d7-8b57-4c91bfd93fce",
+			ModelName:        metadata.SubjectModelName,
+			TargetExternalID: "f1027e6e-17cf-45d7-8b57-4c91bfd93fce",
 		},
 		PackageNodeID: "N:collection:d1011339-b3a0-495d-bf94-76c1a1da1872",
 	})

--- a/service/mappings/fromrecord/contributors.go
+++ b/service/mappings/fromrecord/contributors.go
@@ -1,12 +1,13 @@
 package fromrecord
 
 import (
+	changesetmodels "github.com/pennsieve/processor-post-metadata/client/models"
 	"github.com/pennsieve/processor-pre-metadata/client/models/instance"
 	"github.com/pennsieve/ttl-sync-processor/client/models/metadata"
 )
 
-func ToContributor(record instance.Record) (metadata.Contributor, error) {
-	contributor := metadata.Contributor{}
+func ToContributor(record instance.Record) (metadata.SavedContributor, error) {
+	contributor := metadata.SavedContributor{PennsieveID: changesetmodels.PennsieveInstanceID(record.ID)}
 	if err := checkRecordType(record, metadata.ContributorModelName); err != nil {
 		return contributor, err
 	}

--- a/service/mappings/fromrecord/ids.go
+++ b/service/mappings/fromrecord/ids.go
@@ -1,0 +1,49 @@
+package fromrecord
+
+import (
+	changesetmodels "github.com/pennsieve/processor-post-metadata/client/models"
+)
+
+type RecordIDKey struct {
+	ModelName        string
+	ExternalRecordID changesetmodels.ExternalInstanceID
+}
+
+// RecordIDStore maps (modelName, externalRecordID) -> PennsieveInstanceID and the inverse
+type RecordIDStore struct {
+	externalToPennsieve map[RecordIDKey]changesetmodels.PennsieveInstanceID
+	// pennsieveToExternal is the inverse of externalToPennsieve
+	pennsieveToExternal map[changesetmodels.PennsieveInstanceID]*RecordIDKey
+}
+
+func NewRecordIDStore() *RecordIDStore {
+	return &RecordIDStore{
+		externalToPennsieve: make(map[RecordIDKey]changesetmodels.PennsieveInstanceID),
+		pennsieveToExternal: make(map[changesetmodels.PennsieveInstanceID]*RecordIDKey),
+	}
+}
+
+func (m *RecordIDStore) Add(modelName string, externalRecordID changesetmodels.ExternalInstanceID, recordID changesetmodels.PennsieveInstanceID) {
+	key := RecordIDKey{
+		ModelName:        modelName,
+		ExternalRecordID: externalRecordID,
+	}
+	m.externalToPennsieve[key] = recordID
+	m.pennsieveToExternal[recordID] = &key
+}
+
+func (m *RecordIDStore) GetPennsieve(modelName string, externalRecordID changesetmodels.ExternalInstanceID) (changesetmodels.PennsieveInstanceID, bool) {
+	id, found := m.externalToPennsieve[RecordIDKey{
+		ModelName:        modelName,
+		ExternalRecordID: externalRecordID,
+	}]
+	return id, found
+}
+
+func (m *RecordIDStore) GetExternal(recordID changesetmodels.PennsieveInstanceID) *RecordIDKey {
+	return m.pennsieveToExternal[recordID]
+}
+
+func (m *RecordIDStore) Len() int {
+	return len(m.externalToPennsieve)
+}

--- a/service/mappings/fromrecord/instances.go
+++ b/service/mappings/fromrecord/instances.go
@@ -19,6 +19,9 @@ func ToSavedDatasetMetadata(reader *metadataclient.Reader, idMap *RecordIDStore)
 		return nil, err
 	}
 	for _, s := range existing.Subjects {
+		// Subjects can be linked with Samples and are also the target of package proxies,
+		// so the external IDs of existing records need to be mapped to pennsieve ids in
+		// case they take part in a link or proxy
 		idMap.Add(metadata.SubjectModelName, s.ExternalID(), s.GetPennsieveID())
 	}
 
@@ -26,6 +29,9 @@ func ToSavedDatasetMetadata(reader *metadataclient.Reader, idMap *RecordIDStore)
 		return nil, err
 	}
 	for _, s := range existing.Samples {
+		// Samples can be linked with Subjects and are also the target of package proxies,
+		// so the external IDs of existing records need to be mapped to pennsieve ids in
+		// case they take part in a link or proxy
 		idMap.Add(metadata.SampleModelName, s.ExternalID(), s.GetPennsieveID())
 	}
 	sampleSubjectMapping := NewSampleStoreMapping(idMap)

--- a/service/mappings/fromrecord/instances_test.go
+++ b/service/mappings/fromrecord/instances_test.go
@@ -13,7 +13,9 @@ func TestToDatasetMetadata(t *testing.T) {
 	reader, err := metadataclient.NewReader(inputDirectory)
 	require.NoError(t, err)
 
-	existingMetadata, err := ToSavedDatasetMetadata(reader)
+	idMap := NewRecordIDStore()
+	existingMetadata, err := ToSavedDatasetMetadata(reader, idMap)
+
 	require.NoError(t, err)
 	assert.NotNil(t, existingMetadata)
 	assert.Len(t, existingMetadata.Contributors, 5)
@@ -21,15 +23,19 @@ func TestToDatasetMetadata(t *testing.T) {
 	assert.Len(t, existingMetadata.Samples, 3)
 	assert.Len(t, existingMetadata.SampleSubjects, 2)
 	assert.Len(t, existingMetadata.Proxies, 3)
+	assert.Equal(t, len(existingMetadata.Samples)+len(existingMetadata.Subjects), idMap.Len())
 }
 func TestToDatasetMetadata_NoModels(t *testing.T) {
 	inputDirectory := "testdata/input_no_model"
 
 	reader, err := metadataclient.NewReader(inputDirectory)
 	require.NoError(t, err)
-	existingMetadata, err := ToSavedDatasetMetadata(reader)
+
+	idMap := NewRecordIDStore()
+	existingMetadata, err := ToSavedDatasetMetadata(reader, idMap)
 	require.NoError(t, err)
 	assert.Empty(t, existingMetadata.Contributors)
+	assert.Empty(t, idMap.Len())
 
 }
 
@@ -38,8 +44,11 @@ func TestToDatasetMetadata_NoRecords(t *testing.T) {
 
 	reader, err := metadataclient.NewReader(inputDirectory)
 	require.NoError(t, err)
-	existingMetadata, err := ToSavedDatasetMetadata(reader)
+
+	idMap := NewRecordIDStore()
+	existingMetadata, err := ToSavedDatasetMetadata(reader, idMap)
 	require.NoError(t, err)
 	assert.Empty(t, existingMetadata.Contributors)
+	assert.Empty(t, idMap.Len())
 
 }

--- a/service/mappings/fromrecord/proxies.go
+++ b/service/mappings/fromrecord/proxies.go
@@ -35,8 +35,8 @@ func MapProxies[T metadata.SavedExternalIDer](reader *metadataclient.Reader, mod
 				RecordID:    pennsieveRecordID,
 				Proxy: metadata.Proxy{
 					ProxyKey: metadata.ProxyKey{
-						ModelName: modelName,
-						EntityID:  record.ExternalID(),
+						ModelName:        modelName,
+						TargetExternalID: record.ExternalID(),
 					},
 					PackageNodeID: proxyInstance.Content.NodeID,
 				},

--- a/service/mappings/fromrecord/proxies_test.go
+++ b/service/mappings/fromrecord/proxies_test.go
@@ -26,8 +26,8 @@ func TestMapProxies_Samples(t *testing.T) {
 		RecordID:    "cf811b54-bab7-49f1-b239-79c0f6cac29a",
 		Proxy: metadata.Proxy{
 			ProxyKey: metadata.ProxyKey{
-				ModelName: metadata.SampleModelName,
-				EntityID:  "sample-689",
+				ModelName:        metadata.SampleModelName,
+				TargetExternalID: "sample-689",
 			},
 			PackageNodeID: "N:collection:908d58fd-878f-4c98-8b15-b8092628c79e",
 		},
@@ -38,8 +38,8 @@ func TestMapProxies_Samples(t *testing.T) {
 		RecordID:    "cf811b54-bab7-49f1-b239-79c0f6cac29a",
 		Proxy: metadata.Proxy{
 			ProxyKey: metadata.ProxyKey{
-				EntityID:  "sample-689",
-				ModelName: metadata.SampleModelName,
+				TargetExternalID: "sample-689",
+				ModelName:        metadata.SampleModelName,
 			},
 			PackageNodeID: "N:collection:4e21c210-1880-4ce7-b714-73fc969d66b9",
 		},
@@ -64,8 +64,8 @@ func TestMapProxies_Subjects(t *testing.T) {
 		RecordID:    "a6725f6b-4504-490f-90bc-f21765d0cb07",
 		Proxy: metadata.Proxy{
 			ProxyKey: metadata.ProxyKey{
-				ModelName: metadata.SubjectModelName,
-				EntityID:  "dog-123",
+				ModelName:        metadata.SubjectModelName,
+				TargetExternalID: "dog-123",
 			},
 			PackageNodeID: "N:collection:45229042-690d-4b4a-9a78-7c8e37a6ff20",
 		},

--- a/service/mappings/fromrecord/samplesubject_test.go
+++ b/service/mappings/fromrecord/samplesubject_test.go
@@ -16,12 +16,19 @@ func TestNewSampleStoreMapping(t *testing.T) {
 	reader, err := client.NewReader(inputDirectory)
 	require.NoError(t, err)
 
+	idMap := NewRecordIDStore()
 	samples, err := MapRecords(reader, metadata.SampleModelName, ToSample)
 	require.NoError(t, err)
+	for _, s := range samples {
+		idMap.Add(metadata.SampleModelName, s.ExternalID(), s.GetPennsieveID())
+	}
 	subjects, err := MapRecords(reader, metadata.SubjectModelName, ToSubject)
 	require.NoError(t, err)
+	for _, s := range subjects {
+		idMap.Add(metadata.SubjectModelName, s.ExternalID(), s.GetPennsieveID())
+	}
 
-	mapping := NewSampleStoreMapping(samples, subjects)
+	mapping := NewSampleStoreMapping(idMap)
 
 	sampleSubjectLinks, err := MapLinkedProperties(reader, metadata.SampleSubjectLinkName, mapping)
 	require.NoError(t, err)

--- a/service/processor/metadata.go
+++ b/service/processor/metadata.go
@@ -6,5 +6,5 @@ import (
 )
 
 func (p *CurationExportSyncProcessor) ExistingPennsieveMetadata() (*metadata.SavedDatasetMetadata, error) {
-	return fromrecord.ToSavedDatasetMetadata(p.MetadataReader)
+	return fromrecord.ToSavedDatasetMetadata(p.MetadataReader, p.ExistingRecordIDs)
 }

--- a/service/processor/processor.go
+++ b/service/processor/processor.go
@@ -19,10 +19,13 @@ var logger = logging.PackageLogger("processor")
 const CurationExportFilename = "curation-export.json"
 
 type CurationExportSyncProcessor struct {
-	IntegrationID     string
-	InputDirectory    string
-	OutputDirectory   string
-	MetadataReader    *metadataclient.Reader
+	IntegrationID   string
+	InputDirectory  string
+	OutputDirectory string
+	MetadataReader  *metadataclient.Reader
+	// ExistingRecordIDs needs to be populated with ids of existing records
+	// from any model that takes part in relationships, linked properties, or package proxies
+	// Right now that is only Subjects and Samples
 	ExistingRecordIDs *fromrecord.RecordIDStore
 }
 
@@ -53,6 +56,8 @@ func (p *CurationExportSyncProcessor) Run() error {
 		return err
 	}
 	logger.Info("Computing required changes")
+	// Pass off the ID store to the sync package
+	sync.ExistingRecordStore = p.ExistingRecordIDs
 	changes, err := sync.ComputeChangeset(p.MetadataReader.Schema, oldMetadata, newMetadata)
 	if err != nil {
 		return err

--- a/service/processor/processor.go
+++ b/service/processor/processor.go
@@ -7,6 +7,7 @@ import (
 	changesetmodels "github.com/pennsieve/processor-post-metadata/client/models"
 	metadataclient "github.com/pennsieve/processor-pre-metadata/client"
 	"github.com/pennsieve/ttl-sync-processor/service/logging"
+	"github.com/pennsieve/ttl-sync-processor/service/mappings/fromrecord"
 	"github.com/pennsieve/ttl-sync-processor/service/sync"
 	"log/slog"
 	"os"
@@ -18,10 +19,11 @@ var logger = logging.PackageLogger("processor")
 const CurationExportFilename = "curation-export.json"
 
 type CurationExportSyncProcessor struct {
-	IntegrationID   string
-	InputDirectory  string
-	OutputDirectory string
-	MetadataReader  *metadataclient.Reader
+	IntegrationID     string
+	InputDirectory    string
+	OutputDirectory   string
+	MetadataReader    *metadataclient.Reader
+	ExistingRecordIDs *fromrecord.RecordIDStore
 }
 
 func NewCurationExportSyncProcessor(integrationID string, inputDirectory string, outputDirectory string) (*CurationExportSyncProcessor, error) {
@@ -30,10 +32,11 @@ func NewCurationExportSyncProcessor(integrationID string, inputDirectory string,
 		return nil, fmt.Errorf("error creating metadata reader for %s: %w", inputDirectory, err)
 	}
 	return &CurationExportSyncProcessor{
-		IntegrationID:   integrationID,
-		InputDirectory:  inputDirectory,
-		OutputDirectory: outputDirectory,
-		MetadataReader:  reader,
+		IntegrationID:     integrationID,
+		InputDirectory:    inputDirectory,
+		OutputDirectory:   outputDirectory,
+		MetadataReader:    reader,
+		ExistingRecordIDs: fromrecord.NewRecordIDStore(),
 	}, nil
 }
 

--- a/service/processor/processor_test.go
+++ b/service/processor/processor_test.go
@@ -45,15 +45,13 @@ func TestCurationExportSyncProcessor_Run(t *testing.T) {
 	// model exists, so ID should be present and Create nil
 	assert.Nil(t, contributorChanges.Create)
 
-	assert.True(t, contributorChanges.Records.DeleteAll)
 	assert.Len(t, contributorChanges.Records.Create, 3)
 	assert.Empty(t, contributorChanges.Records.Update)
-	assert.Empty(t, contributorChanges.Records.Delete)
+	assert.Len(t, contributorChanges.Records.Delete, 5)
 
 	// Subjects
 	subjectChanges := findModelChangesByID(t, changeset.Models, "44fe1f90-f7b5-407a-8689-c512d7f41b7d")
 	assert.Nil(t, subjectChanges.Create)
-	assert.False(t, subjectChanges.Records.DeleteAll)
 	assert.Len(t, subjectChanges.Records.Delete, 1)
 	assert.Empty(t, subjectChanges.Records.Update)
 	assert.Len(t, subjectChanges.Records.Create, 2)
@@ -61,7 +59,6 @@ func TestCurationExportSyncProcessor_Run(t *testing.T) {
 	// Samples
 	sampleChanges := findModelChangesByID(t, changeset.Models, "29756423-00de-42f8-8706-acdcb1823685")
 	assert.Nil(t, sampleChanges.Create)
-	assert.False(t, sampleChanges.Records.DeleteAll)
 	assert.Len(t, sampleChanges.Records.Delete, 2)
 	assert.Len(t, sampleChanges.Records.Update, 1)
 	assert.Len(t, sampleChanges.Records.Create, 2)
@@ -114,7 +111,7 @@ func TestCurationExportSyncProcessor_ReadCurationExport(t *testing.T) {
 
 func findModelChangesByID(t *testing.T, modelChanges []changesetmodels.ModelChanges, modelID string) changesetmodels.ModelChanges {
 	index := slices.IndexFunc(modelChanges, func(changes changesetmodels.ModelChanges) bool {
-		return changes.ID == modelID
+		return changes.ID.String() == modelID
 	})
 	require.GreaterOrEqual(t, index, 0)
 	return modelChanges[index]

--- a/service/spec/links.go
+++ b/service/spec/links.go
@@ -13,10 +13,8 @@ type Link struct {
 
 func (l Link) SchemaCreate() changesetmodels.SchemaLinkedPropertyCreate {
 	return changesetmodels.SchemaLinkedPropertyCreate{
-		Name:          l.Name,
-		DisplayName:   l.DisplayName,
-		FromModelName: l.FromModelName,
-		ToModelName:   l.ToModelName,
-		Position:      l.Position,
+		Name:        l.Name,
+		DisplayName: l.DisplayName,
+		Position:    l.Position,
 	}
 }

--- a/service/spec/sample.go
+++ b/service/spec/sample.go
@@ -26,7 +26,10 @@ var SampleInstance = IdentifiableInstance[metadata.SavedSample, metadata.Sample]
 		var values []changesetmodels.RecordValue
 		values = appendNonEmptyRecordValue(values, metadata.SampleIDKey, new.ExternalID())
 		values = appendNonEmptyRecordValue(values, metadata.PrimaryKeyKey, new.PrimaryKey)
-		return changesetmodels.RecordCreate{Values: values}
+		return changesetmodels.RecordCreate{
+			ExternalID:   new.ExternalID(),
+			RecordValues: changesetmodels.RecordValues{Values: values},
+		}
 	},
 	Updater: func(old metadata.SavedSample, new metadata.Sample) (*changesetmodels.RecordUpdate, error) {
 		if old.ExternalID() != new.ExternalID() {

--- a/service/spec/subject.go
+++ b/service/spec/subject.go
@@ -28,7 +28,10 @@ var SubjectInstance = IdentifiableInstance[metadata.SavedSubject, metadata.Subje
 		values = appendNonEmptyRecordValue(values, metadata.SubjectIDKey, subject.ID)
 		values = appendNonEmptyRecordValue(values, metadata.SpeciesKey, subject.Species)
 		values = appendNonEmptyRecordValue(values, metadata.SpeciesSynonymsKey, subject.SpeciesSynonyms)
-		return changesetmodels.RecordCreate{Values: values}
+		return changesetmodels.RecordCreate{
+			ExternalID:   subject.ExternalID(),
+			RecordValues: changesetmodels.RecordValues{Values: values},
+		}
 	},
 	Updater: func(oldSubject metadata.SavedSubject, newSubject metadata.Subject) (*changesetmodels.RecordUpdate, error) {
 		// since we are identifying old and new based on GetID(), it doesn't make sense to update the ID

--- a/service/sync/contributors.go
+++ b/service/sync/contributors.go
@@ -9,7 +9,7 @@ import (
 	"log/slog"
 )
 
-func ComputeContributorsChanges(schemaData *metadataclient.Schema, old []metadata.Contributor, new []metadata.Contributor) (*changesetmodels.ModelChanges, error) {
+func ComputeContributorsChanges(schemaData *metadataclient.Schema, old []metadata.SavedContributor, new []metadata.Contributor) (*changesetmodels.ModelChanges, error) {
 	oldHash, err := metadata.ComputeHash(old)
 	if err != nil {
 		return nil, fmt.Errorf("error computing hash of existing contributors metadata: %w", err)
@@ -32,7 +32,9 @@ func ComputeContributorsChanges(schemaData *metadataclient.Schema, old []metadat
 		slog.Int("toCreateCount", len(new)),
 	)
 	// hashes are different, so clear out existing records and create new ones from incoming
-	changes.Records.DeleteAll = true
+	for _, contributor := range old {
+		changes.Records.Delete = append(changes.Records.Delete, contributor.GetPennsieveID())
+	}
 	for _, contributor := range new {
 		create := spec.ContributorInstance.Creator(contributor)
 		changes.Records.Create = append(changes.Records.Create, create)

--- a/service/sync/contributors_test.go
+++ b/service/sync/contributors_test.go
@@ -27,7 +27,7 @@ func TestComputeContributorsChanges(t *testing.T) {
 }
 
 func everythingEmpty(t *testing.T) {
-	changes, err := ComputeContributorsChanges(emptySchema, []metadata.Contributor{}, []metadata.Contributor{})
+	changes, err := ComputeContributorsChanges(emptySchema, []metadata.SavedContributor{}, []metadata.Contributor{})
 	require.NoError(t, err)
 	// Nil changes means no updates required.
 	require.Nil(t, changes)
@@ -35,7 +35,7 @@ func everythingEmpty(t *testing.T) {
 
 func modelDoesNotExist(t *testing.T) {
 	newContrib := metadatatest.NewContributorBuilder().WithMiddleInitial().Build()
-	changes, err := ComputeContributorsChanges(emptySchema, []metadata.Contributor{}, []metadata.Contributor{newContrib})
+	changes, err := ComputeContributorsChanges(emptySchema, []metadata.SavedContributor{}, []metadata.Contributor{newContrib})
 	require.NoError(t, err)
 	require.NotNil(t, changes)
 
@@ -45,11 +45,11 @@ func modelDoesNotExist(t *testing.T) {
 	assert.Len(t, changes.Create.Properties, 6)
 
 	assert.NotNil(t, changes.Records)
-	assert.True(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Update)
 	assert.Empty(t, changes.Records.Delete)
 
 	assert.Len(t, changes.Records.Create, 1)
+	assert.NotEmpty(t, changes.Records.Create[0].ExternalID)
 	values := changes.Records.Create[0].Values
 	// Only contains first and last names and middle initial because other values are empty
 	assert.Len(t, values, 3)
@@ -72,22 +72,22 @@ func modelExistsButNoExistingRecords(t *testing.T) {
 	newContrib := metadatatest.NewContributorBuilder().WithMiddleInitial().Build()
 	newContrib2 := metadatatest.NewContributorBuilder().WithNodeID().Build()
 
-	changes, err := ComputeContributorsChanges(schemaData, []metadata.Contributor{}, []metadata.Contributor{newContrib, newContrib2})
+	changes, err := ComputeContributorsChanges(schemaData, []metadata.SavedContributor{}, []metadata.Contributor{newContrib, newContrib2})
 	require.NoError(t, err)
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.ContributorModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.True(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Update)
 	assert.Empty(t, changes.Records.Delete)
 
 	assert.Len(t, changes.Records.Create, 2)
 	// First Contributor
 	{
+		assert.NotEmpty(t, changes.Records.Create[0].ExternalID)
 		values := changes.Records.Create[0].Values
 		// Only contains first and last names and middle initial because other values are empty
 		assert.Len(t, values, 3)
@@ -106,6 +106,7 @@ func modelExistsButNoExistingRecords(t *testing.T) {
 
 	//Second Contributor
 	{
+		assert.NotEmpty(t, changes.Records.Create[1].ExternalID)
 		values := changes.Records.Create[1].Values
 		// Only contains first and last names and node id because other values are empty
 		assert.Len(t, values, 3)
@@ -132,7 +133,7 @@ func noChanges(t *testing.T) {
 
 	changes, err := ComputeContributorsChanges(
 		schemaData,
-		[]metadata.Contributor{contrib, contrib2},
+		[]metadata.SavedContributor{metadatatest.NewSavedContributor(contrib), metadatatest.NewSavedContributor(contrib2)},
 		[]metadata.Contributor{contrib, contrib2},
 	)
 	require.NoError(t, err)
@@ -145,26 +146,28 @@ func orderChange(t *testing.T) {
 	contrib := metadatatest.NewContributorBuilder().WithMiddleInitial().Build()
 	contrib2 := metadatatest.NewContributorBuilder().WithNodeID().Build()
 
+	savedContrib := metadatatest.NewSavedContributor(contrib2)
+	savedContrib2 := metadatatest.NewSavedContributor(contrib)
 	changes, err := ComputeContributorsChanges(
 		schemaData,
-		[]metadata.Contributor{contrib2, contrib},
+		[]metadata.SavedContributor{savedContrib, savedContrib2},
 		[]metadata.Contributor{contrib, contrib2},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.ContributorModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.True(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Update)
-	assert.Empty(t, changes.Records.Delete)
+	assert.Equal(t, []changesetmodels.PennsieveInstanceID{savedContrib.GetPennsieveID(), savedContrib2.GetPennsieveID()}, changes.Records.Delete)
 
 	assert.Len(t, changes.Records.Create, 2)
 	// First Contributor
 	{
+		assert.NotEmpty(t, changes.Records.Create[0].ExternalID)
 		values := changes.Records.Create[0].Values
 		// Only contains first and last names and middle initial because other values are empty
 		assert.Len(t, values, 3)
@@ -183,6 +186,7 @@ func orderChange(t *testing.T) {
 
 	//Second Contributor
 	{
+		assert.NotEmpty(t, changes.Records.Create[1].ExternalID)
 		values := changes.Records.Create[1].Values
 		// Only contains first and last names and node id because other values are empty
 		assert.Len(t, values, 3)
@@ -207,26 +211,30 @@ func removeContributor(t *testing.T) {
 	contrib2 := metadatatest.NewContributorBuilder().WithNodeID().Build()
 	contrib3 := metadatatest.NewContributorBuilder().WithDegree().Build()
 
+	savedContrib := metadatatest.NewSavedContributor(contrib)
+	savedContrib2 := metadatatest.NewSavedContributor(contrib2)
+	savedContrib3 := metadatatest.NewSavedContributor(contrib3)
+
 	changes, err := ComputeContributorsChanges(
 		schemaData,
-		[]metadata.Contributor{contrib3, contrib2, contrib},
+		[]metadata.SavedContributor{savedContrib3, savedContrib2, savedContrib},
 		[]metadata.Contributor{contrib, contrib2},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.ContributorModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.True(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Update)
-	assert.Empty(t, changes.Records.Delete)
+	assert.Equal(t, []changesetmodels.PennsieveInstanceID{savedContrib3.GetPennsieveID(), savedContrib2.GetPennsieveID(), savedContrib.GetPennsieveID()}, changes.Records.Delete)
 
 	assert.Len(t, changes.Records.Create, 2)
 	// First Contributor
 	{
+		assert.NotEmpty(t, changes.Records.Create[0].ExternalID)
 		values := changes.Records.Create[0].Values
 		// Only contains first and last names and middle initial because other values are empty
 		assert.Len(t, values, 3)
@@ -245,6 +253,7 @@ func removeContributor(t *testing.T) {
 
 	//Second Contributor
 	{
+		assert.NotEmpty(t, changes.Records.Create[1].ExternalID)
 		values := changes.Records.Create[1].Values
 		// Only contains first and last names and node id because other values are empty
 		assert.Len(t, values, 3)
@@ -268,26 +277,28 @@ func addContributor(t *testing.T) {
 	contrib := metadatatest.NewContributorBuilder().WithMiddleInitial().Build()
 	contrib2 := metadatatest.NewContributorBuilder().WithNodeID().Build()
 
+	savedContrib := metadatatest.NewSavedContributor(contrib)
+
 	changes, err := ComputeContributorsChanges(
 		schemaData,
-		[]metadata.Contributor{contrib},
+		[]metadata.SavedContributor{savedContrib},
 		[]metadata.Contributor{contrib, contrib2},
 	)
 	require.NoError(t, err)
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.ContributorModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.True(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Update)
-	assert.Empty(t, changes.Records.Delete)
 
+	assert.Equal(t, []changesetmodels.PennsieveInstanceID{savedContrib.GetPennsieveID()}, changes.Records.Delete)
 	assert.Len(t, changes.Records.Create, 2)
 	// First Contributor
 	{
+		assert.NotEmpty(t, changes.Records.Create[0].ExternalID)
 		values := changes.Records.Create[0].Values
 		// Only contains first and last names and middle initial because other values are empty
 		assert.Len(t, values, 3)
@@ -306,6 +317,7 @@ func addContributor(t *testing.T) {
 
 	//Second Contributor
 	{
+		assert.NotEmpty(t, changes.Records.Create[1].ExternalID)
 		values := changes.Records.Create[1].Values
 		// Only contains first and last names and node id because other values are empty
 		assert.Len(t, values, 3)

--- a/service/sync/linkdiff.go
+++ b/service/sync/linkdiff.go
@@ -72,9 +72,11 @@ func addIdentifiableLinkedPropertyChanges[OLD metadata.SavedExternalLink, NEW me
 }
 
 func setLinkIDOrCreate(linkChanges *changesetmodels.LinkedPropertyChanges, schemaData *metadataclient.Schema, linkSpec spec.Link) error {
+	linkChanges.FromModelName = linkSpec.FromModelName
+	linkChanges.ToModelName = linkSpec.ToModelName
 	if linkSchema, linkSchemaExists := schemaData.LinkedPropertyByName(linkSpec.Name); linkSchemaExists {
 		logger.Info("linkSchema exists", slog.String("linkSchemaName", linkSchema.Name), slog.String("linkSchemaID", linkSchema.ID))
-		linkChanges.ID = linkSchema.ID
+		linkChanges.ID = changesetmodels.PennsieveSchemaID(linkSchema.ID)
 	} else {
 		schemaCreate := linkSpec.SchemaCreate()
 		logger.Info("linkSchema must be created", slog.String("linkName", linkSpec.Name))

--- a/service/sync/proxydiff.go
+++ b/service/sync/proxydiff.go
@@ -48,7 +48,7 @@ func addProxyInstanceChanges(old []metadata.SavedProxy, new []metadata.Proxy) (*
 			proxyChanges, entryInitialized := changesByProxyKey[newInstance.ProxyKey]
 			if !entryInitialized {
 				proxyChanges.ModelName = newInstance.ModelName
-				proxyChanges.RecordExternalID = newInstance.EntityID
+				proxyChanges.RecordExternalID = newInstance.TargetExternalID
 			}
 			proxyChanges.NodeIDCreates = append(proxyChanges.NodeIDCreates, newInstance.PackageNodeID)
 			changesByProxyKey[newInstance.ProxyKey] = proxyChanges
@@ -60,7 +60,7 @@ func addProxyInstanceChanges(old []metadata.SavedProxy, new []metadata.Proxy) (*
 			proxyChanges, entryInitialized := changesByProxyKey[toDelete.ProxyKey]
 			if !entryInitialized {
 				proxyChanges.ModelName = toDelete.ModelName
-				proxyChanges.RecordExternalID = toDelete.EntityID
+				proxyChanges.RecordExternalID = toDelete.TargetExternalID
 			}
 			proxyChanges.InstanceIDDeletes = append(proxyChanges.InstanceIDDeletes, toDelete.GetPennsieveID())
 			changesByProxyKey[toDelete.ProxyKey] = proxyChanges

--- a/service/sync/proxydiff.go
+++ b/service/sync/proxydiff.go
@@ -47,8 +47,13 @@ func addProxyInstanceChanges(old []metadata.SavedProxy, new []metadata.Proxy) (*
 		if _, exists := oldByID[newID]; !exists {
 			proxyChanges, entryInitialized := changesByProxyKey[newInstance.ProxyKey]
 			if !entryInitialized {
-				proxyChanges.ModelName = newInstance.ModelName
-				proxyChanges.RecordExternalID = newInstance.TargetExternalID
+				modelName := newInstance.ModelName
+				targetExternalID := newInstance.TargetExternalID
+				if targetPennsieveID, found := ExistingRecordStore.GetPennsieve(modelName, targetExternalID); found {
+					recordIDMap.Add(modelName, targetExternalID, targetPennsieveID)
+				}
+				proxyChanges.ModelName = modelName
+				proxyChanges.RecordExternalID = targetExternalID
 			}
 			proxyChanges.NodeIDCreates = append(proxyChanges.NodeIDCreates, newInstance.PackageNodeID)
 			changesByProxyKey[newInstance.ProxyKey] = proxyChanges

--- a/service/sync/proxydiff_test.go
+++ b/service/sync/proxydiff_test.go
@@ -35,11 +35,16 @@ func emptyChangesProxies(t *testing.T) {
 	changes, err := ComputeProxyChanges(emptySchema, []metadata.SavedProxy{}, []metadata.Proxy{})
 	require.NoError(t, err)
 	assert.Nil(t, changes)
+	assert.Empty(t, recordIDMap)
 }
 
 func proxySchemaDoesNotExist(t *testing.T) {
 	proxy1 := metadatatest.NewProxy(metadata.SampleModelName)
 	proxy2 := metadatatest.NewProxy(metadata.SubjectModelName)
+
+	// make the record of proxy1 an existing record not otherwise known to this sync
+	proxy1TargetPennsieveID := metadatatest.NewPennsieveInstanceID()
+	ExistingRecordStore.Add(metadata.SampleModelName, proxy1.TargetExternalID, proxy1TargetPennsieveID)
 
 	changes, err := ComputeProxyChanges(emptySchema, []metadata.SavedProxy{}, []metadata.Proxy{proxy1, proxy2})
 	require.NoError(t, err)
@@ -58,11 +63,21 @@ func proxySchemaDoesNotExist(t *testing.T) {
 	require.NotNil(t, changes2)
 	assert.Empty(t, changes2.InstanceIDDeletes)
 	assert.Contains(t, changes2.NodeIDCreates, proxy2.PackageNodeID)
+
+	assert.Len(t, recordIDMap, 1)
+	assert.Equal(t, proxy1TargetPennsieveID, recordIDMap[fromrecord.RecordIDKey{
+		ModelName:        metadata.SampleModelName,
+		ExternalRecordID: proxy1.TargetExternalID,
+	}])
 }
 
 func proxySchemaExistsButNoInstances(t *testing.T) {
 	proxy1 := metadatatest.NewProxy(metadata.SampleModelName)
 	proxy2 := metadatatest.NewProxy(metadata.SubjectModelName)
+
+	// make the record of proxy2 an existing record not otherwise known to this sync
+	proxy2TargetPennsieveID := metadatatest.NewPennsieveInstanceID()
+	ExistingRecordStore.Add(metadata.SubjectModelName, proxy2.TargetExternalID, proxy2TargetPennsieveID)
 
 	changes, err := ComputeProxyChanges(fullSchema(), []metadata.SavedProxy{}, []metadata.Proxy{proxy1, proxy2})
 	require.NoError(t, err)
@@ -83,6 +98,12 @@ func proxySchemaExistsButNoInstances(t *testing.T) {
 	assert.Empty(t, changes2.InstanceIDDeletes)
 	assert.Len(t, changes2.NodeIDCreates, 1)
 	assert.Contains(t, changes2.NodeIDCreates, proxy2.PackageNodeID)
+
+	assert.Len(t, recordIDMap, 1)
+	assert.Equal(t, proxy2TargetPennsieveID, recordIDMap[fromrecord.RecordIDKey{
+		ModelName:        metadata.SubjectModelName,
+		ExternalRecordID: proxy2.TargetExternalID,
+	}])
 }
 
 func noProxyChanges(t *testing.T) {
@@ -96,6 +117,7 @@ func noProxyChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Nil(t, changes)
+	assert.Empty(t, recordIDMap)
 }
 
 func proxyOrderDoesNotMatter(t *testing.T) {
@@ -109,6 +131,8 @@ func proxyOrderDoesNotMatter(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Nil(t, changes)
+	assert.Empty(t, recordIDMap)
+
 }
 
 func proxyDeleted(t *testing.T) {
@@ -133,6 +157,8 @@ func proxyDeleted(t *testing.T) {
 	assert.Empty(t, recordChanges.NodeIDCreates)
 	assert.Len(t, recordChanges.InstanceIDDeletes, 1)
 	assert.Contains(t, recordChanges.InstanceIDDeletes, savedDeletedProxy.GetPennsieveID())
+	assert.Empty(t, recordIDMap)
+
 }
 
 func proxyChangeRecordID(t *testing.T) {
@@ -156,11 +182,15 @@ func proxyChangeRecordID(t *testing.T) {
 	assert.Empty(t, createChanges.InstanceIDDeletes)
 	assert.Len(t, createChanges.NodeIDCreates, 1)
 	assert.Contains(t, createChanges.NodeIDCreates, newProxy.PackageNodeID)
+	assert.Empty(t, recordIDMap)
+
 }
 
 func proxyChangeNodeID(t *testing.T) {
 	oldProxy := metadatatest.NewSavedProxy(metadatatest.NewProxy(metadata.SampleModelName))
 	newProxy := metadatatest.NewProxyBuilder().WithEntityID(oldProxy.TargetExternalID).Build(metadata.SampleModelName)
+	targetPennsieveID := metadatatest.NewPennsieveInstanceID()
+	ExistingRecordStore.Add(metadata.SampleModelName, oldProxy.TargetExternalID, targetPennsieveID)
 
 	changes, err := ComputeProxyChanges(fullSchema(), []metadata.SavedProxy{oldProxy}, []metadata.Proxy{newProxy})
 	require.NoError(t, err)
@@ -177,6 +207,12 @@ func proxyChangeNodeID(t *testing.T) {
 
 	assert.Len(t, recordChanges.InstanceIDDeletes, 1)
 	assert.Contains(t, recordChanges.InstanceIDDeletes, oldProxy.GetPennsieveID())
+
+	assert.Len(t, recordIDMap, 1)
+	assert.Equal(t, targetPennsieveID, recordIDMap[fromrecord.RecordIDKey{
+		ModelName:        metadata.SampleModelName,
+		ExternalRecordID: oldProxy.TargetExternalID,
+	}])
 
 }
 

--- a/service/sync/sample_test.go
+++ b/service/sync/sample_test.go
@@ -49,13 +49,13 @@ func sampleModelDoesNotExist(t *testing.T) {
 	assert.Len(t, changes.Create.Properties, 2)
 
 	assert.NotNil(t, changes.Records)
-	assert.False(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Update)
 	assert.Empty(t, changes.Records.Delete)
 
 	assert.Len(t, changes.Records.Create, 2)
 	// The Create for newSample1
 	{
+		assert.Equal(t, newSample1.ExternalID(), changes.Records.Create[0].ExternalID)
 		values := changes.Records.Create[0].Values
 		// Only contains ID since that is the only property
 		assert.Len(t, values, 2)
@@ -73,6 +73,7 @@ func sampleModelDoesNotExist(t *testing.T) {
 
 	// The Create for newSample2
 	{
+		assert.Equal(t, newSample2.ExternalID(), changes.Records.Create[1].ExternalID)
 		values := changes.Records.Create[1].Values
 		// Only contains ID and species because other values are empty
 		assert.Len(t, values, 2)
@@ -103,17 +104,17 @@ func sampleModelExistsButNoExistingRecords(t *testing.T) {
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.SampleModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.False(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Update)
 	assert.Empty(t, changes.Records.Delete)
 
 	assert.Len(t, changes.Records.Create, 2)
 	// The Create for newSample1
 	{
+		assert.Equal(t, newSample1.ExternalID(), changes.Records.Create[0].ExternalID)
 		values := changes.Records.Create[0].Values
 		// Only contains ID
 		assert.Len(t, values, 2)
@@ -131,6 +132,7 @@ func sampleModelExistsButNoExistingRecords(t *testing.T) {
 
 	// The Create for newSample2
 	{
+		assert.Equal(t, newSample2.ExternalID(), changes.Records.Create[1].ExternalID)
 		values := changes.Records.Create[1].Values
 		// Only contains ID
 		assert.Len(t, values, 2)
@@ -200,11 +202,10 @@ func deleteSample(t *testing.T) {
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.SampleModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.False(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Create)
 	assert.Empty(t, changes.Records.Update)
 
@@ -236,11 +237,10 @@ func updateSample(t *testing.T) {
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.SampleModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.False(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Create)
 	assert.Empty(t, changes.Records.Delete)
 

--- a/service/sync/samplesubject_test.go
+++ b/service/sync/samplesubject_test.go
@@ -4,6 +4,7 @@ import (
 	metadataclient "github.com/pennsieve/processor-pre-metadata/client"
 	"github.com/pennsieve/ttl-sync-processor/client/metadatatest"
 	"github.com/pennsieve/ttl-sync-processor/client/models/metadata"
+	"github.com/pennsieve/ttl-sync-processor/service/mappings/fromrecord"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -21,6 +22,13 @@ func TestComputeSampleSubjectChanges(t *testing.T) {
 		"change subject id (to)":      sampleSubjectChangeSubjectID,
 	} {
 		t.Run(scenario, func(t *testing.T) {
+			// Need to initialize these package-wide vars for each test
+			// Individual test functions should populate ExistingRecordStore
+			// to simulate different situations and then
+			// check that recordIDMap has the expected entries.
+			ExistingRecordStore = fromrecord.NewRecordIDStore()
+			recordIDMap = make(fromrecord.RecordIDMap)
+
 			test(t)
 		})
 	}
@@ -30,10 +38,16 @@ func emptyChangesSampleSubject(t *testing.T) {
 	changes, err := ComputeSampleSubjectChanges(emptySchema, []metadata.SavedSampleSubject{}, []metadata.SampleSubject{})
 	require.NoError(t, err)
 	assert.Nil(t, changes)
+	assert.Empty(t, recordIDMap)
 }
 func sampleSubjectLinkSchemaDoesNotExist(t *testing.T) {
 	link1 := metadatatest.NewSampleSubject()
 	link2 := metadatatest.NewSampleSubject()
+
+	// This means that only the subject of link2 already existed in the
+	// dataset's metadata
+	link2ToPennsieveID := metadatatest.NewPennsieveInstanceID()
+	ExistingRecordStore.Add(metadata.SubjectModelName, link2.ToExternalID(), link2ToPennsieveID)
 
 	changes, err := ComputeSampleSubjectChanges(emptySchema, []metadata.SavedSampleSubject{}, []metadata.SampleSubject{link1, link2})
 	require.NoError(t, err)
@@ -65,6 +79,11 @@ func sampleSubjectLinkSchemaDoesNotExist(t *testing.T) {
 		assert.Equal(t, link2.FromExternalID(), create.FromExternalID)
 		assert.Equal(t, link2.ToExternalID(), create.ToExternalID)
 	}
+	assert.Len(t, recordIDMap, 1)
+	assert.Equal(t, link2ToPennsieveID, recordIDMap[fromrecord.RecordIDKey{
+		ModelName:        metadata.SubjectModelName,
+		ExternalRecordID: link2.ToExternalID(),
+	}])
 
 }
 
@@ -104,6 +123,8 @@ func sampleSubjectSchemaExistsButNoInstances(t *testing.T) {
 		assert.Equal(t, link2.FromExternalID(), create.FromExternalID)
 		assert.Equal(t, link2.ToExternalID(), create.ToExternalID)
 	}
+
+	assert.Empty(t, recordIDMap)
 }
 
 func noSampleSubjectChanges(t *testing.T) {
@@ -117,10 +138,14 @@ func noSampleSubjectChanges(t *testing.T) {
 
 	savedLink1 := metadatatest.NewSavedSampleSubject(link1)
 	savedLink2 := metadatatest.NewSavedSampleSubject(link2)
+	addSavedSampleSubjectRecordIDs(ExistingRecordStore, savedLink1)
+	addSavedSampleSubjectRecordIDs(ExistingRecordStore, savedLink2)
 
 	changes, err := ComputeSampleSubjectChanges(schemaData, []metadata.SavedSampleSubject{savedLink1, savedLink2}, []metadata.SampleSubject{link1, link2})
 	require.NoError(t, err)
 	assert.Nil(t, changes)
+	assert.Empty(t, recordIDMap)
+
 }
 
 func sampleSubjectOrderDoesNotMatter(t *testing.T) {
@@ -134,10 +159,14 @@ func sampleSubjectOrderDoesNotMatter(t *testing.T) {
 
 	savedLink1 := metadatatest.NewSavedSampleSubject(link1)
 	savedLink2 := metadatatest.NewSavedSampleSubject(link2)
+	addSavedSampleSubjectRecordIDs(ExistingRecordStore, savedLink1)
+	addSavedSampleSubjectRecordIDs(ExistingRecordStore, savedLink2)
 
 	changes, err := ComputeSampleSubjectChanges(schemaData, []metadata.SavedSampleSubject{savedLink2, savedLink1}, []metadata.SampleSubject{link1, link2})
 	require.NoError(t, err)
 	assert.Nil(t, changes)
+	assert.Empty(t, recordIDMap)
+
 }
 
 func sampleSubjectDeleted(t *testing.T) {
@@ -165,6 +194,8 @@ func sampleSubjectDeleted(t *testing.T) {
 
 	assert.Empty(t, changes.Instances.Create)
 	assert.Len(t, changes.Instances.Delete, 1)
+	assert.Empty(t, recordIDMap)
+
 }
 
 func sampleSubjectChangeSampleID(t *testing.T) {
@@ -176,6 +207,7 @@ func sampleSubjectChangeSampleID(t *testing.T) {
 
 	oldLink := metadatatest.NewSavedSampleSubject(metadatatest.NewSampleSubject())
 	newLink := metadatatest.NewSampleSubjectBuilder().WithSubjectID(oldLink.SubjectID).Build()
+	addSavedSampleSubjectRecordIDs(ExistingRecordStore, oldLink)
 
 	changes, err := ComputeSampleSubjectChanges(schemaData, []metadata.SavedSampleSubject{oldLink}, []metadata.SampleSubject{newLink})
 	require.NoError(t, err)
@@ -195,6 +227,10 @@ func sampleSubjectChangeSampleID(t *testing.T) {
 	assert.Len(t, creates, 1)
 	assert.Equal(t, newLink.FromExternalID(), creates[0].FromExternalID)
 	assert.Equal(t, newLink.ToExternalID(), creates[0].ToExternalID)
+
+	assert.Len(t, recordIDMap, 1)
+	assert.Equal(t, oldLink.ToPennsieveID(),
+		recordIDMap[fromrecord.RecordIDKey{ModelName: metadata.SubjectModelName, ExternalRecordID: oldLink.ToExternalID()}])
 }
 
 func sampleSubjectChangeSubjectID(t *testing.T) {
@@ -206,6 +242,7 @@ func sampleSubjectChangeSubjectID(t *testing.T) {
 
 	oldLink := metadatatest.NewSavedSampleSubject(metadatatest.NewSampleSubject())
 	newLink := metadatatest.NewSampleSubjectBuilder().WithSampleID(oldLink.SampleID).Build()
+	addSavedSampleSubjectRecordIDs(ExistingRecordStore, oldLink)
 
 	changes, err := ComputeSampleSubjectChanges(schemaData, []metadata.SavedSampleSubject{oldLink}, []metadata.SampleSubject{newLink})
 	require.NoError(t, err)
@@ -225,4 +262,21 @@ func sampleSubjectChangeSubjectID(t *testing.T) {
 	assert.Len(t, creates, 1)
 	assert.Equal(t, newLink.FromExternalID(), creates[0].FromExternalID)
 	assert.Equal(t, newLink.ToExternalID(), creates[0].ToExternalID)
+
+	assert.Len(t, recordIDMap, 1)
+	assert.Equal(t, oldLink.FromPennsieveID(),
+		recordIDMap[fromrecord.RecordIDKey{ModelName: metadata.SampleModelName, ExternalRecordID: oldLink.FromExternalID()}])
+}
+
+func addSavedSampleSubjectRecordIDs(existingRecordIDs *fromrecord.RecordIDStore, savedSampleSubject metadata.SavedSampleSubject) {
+	existingRecordIDs.Add(metadata.SampleModelName, savedSampleSubject.FromExternalID(), savedSampleSubject.FromPennsieveID())
+	existingRecordIDs.Add(metadata.SubjectModelName, savedSampleSubject.ToExternalID(), savedSampleSubject.ToPennsieveID())
+}
+
+func addSavedSampleRecordID(existingRecordIDs *fromrecord.RecordIDStore, savedSample metadata.SavedSample) {
+	existingRecordIDs.Add(metadata.SampleModelName, savedSample.ExternalID(), savedSample.GetPennsieveID())
+}
+
+func addSavedSubjectRecordID(existingRecordIDs *fromrecord.RecordIDStore, savedSubject metadata.SavedSubject) {
+	existingRecordIDs.Add(metadata.SubjectModelName, savedSubject.ExternalID(), savedSubject.GetPennsieveID())
 }

--- a/service/sync/samplesubject_test.go
+++ b/service/sync/samplesubject_test.go
@@ -41,10 +41,11 @@ func sampleSubjectLinkSchemaDoesNotExist(t *testing.T) {
 	// no link schema, so no ID and we need to supply the correct info to create schema
 	assert.Empty(t, changes.ID)
 	assert.NotNil(t, changes.Create)
+	assert.Equal(t, metadata.SampleModelName, changes.FromModelName)
+	assert.Equal(t, metadata.SubjectModelName, changes.ToModelName)
 	assert.Equal(t, metadata.SampleSubjectLinkName, changes.Create.Name)
 	assert.Equal(t, metadata.SampleSubjectLinkDisplayName, changes.Create.DisplayName)
-	assert.Equal(t, metadata.SampleModelName, changes.Create.FromModelName)
-	assert.Equal(t, metadata.SubjectModelName, changes.Create.ToModelName)
+
 	assert.Equal(t, 1, changes.Create.Position)
 
 	// Need to create two link instances and no deletes
@@ -79,8 +80,11 @@ func sampleSubjectSchemaExistsButNoInstances(t *testing.T) {
 	changes, err := ComputeSampleSubjectChanges(schemaData, []metadata.SavedSampleSubject{}, []metadata.SampleSubject{link1, link2})
 	require.NoError(t, err)
 
+	assert.Equal(t, metadata.SampleModelName, changes.FromModelName)
+	assert.Equal(t, metadata.SubjectModelName, changes.ToModelName)
+
 	expectedLinkSchema, _ := schemaData.LinkedPropertyByName(metadata.SampleSubjectLinkName)
-	assert.Equal(t, expectedLinkSchema.ID, changes.ID)
+	assert.Equal(t, expectedLinkSchema.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	// Need to create two link instances and no deletes
@@ -152,8 +156,11 @@ func sampleSubjectDeleted(t *testing.T) {
 	changes, err := ComputeSampleSubjectChanges(schemaData, []metadata.SavedSampleSubject{savedLink2, deletedLink, savedLink1}, []metadata.SampleSubject{link1, link2})
 	require.NoError(t, err)
 
+	assert.Equal(t, metadata.SampleModelName, changes.FromModelName)
+	assert.Equal(t, metadata.SubjectModelName, changes.ToModelName)
+
 	expectedLinkSchema, _ := schemaData.LinkedPropertyByName(metadata.SampleSubjectLinkName)
-	assert.Equal(t, expectedLinkSchema.ID, changes.ID)
+	assert.Equal(t, expectedLinkSchema.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.Empty(t, changes.Instances.Create)
@@ -172,6 +179,9 @@ func sampleSubjectChangeSampleID(t *testing.T) {
 
 	changes, err := ComputeSampleSubjectChanges(schemaData, []metadata.SavedSampleSubject{oldLink}, []metadata.SampleSubject{newLink})
 	require.NoError(t, err)
+
+	assert.Equal(t, metadata.SampleModelName, changes.FromModelName)
+	assert.Equal(t, metadata.SubjectModelName, changes.ToModelName)
 
 	assert.Nil(t, changes.Create)
 	assert.NotEmpty(t, changes.ID)
@@ -199,6 +209,9 @@ func sampleSubjectChangeSubjectID(t *testing.T) {
 
 	changes, err := ComputeSampleSubjectChanges(schemaData, []metadata.SavedSampleSubject{oldLink}, []metadata.SampleSubject{newLink})
 	require.NoError(t, err)
+
+	assert.Equal(t, metadata.SampleModelName, changes.FromModelName)
+	assert.Equal(t, metadata.SubjectModelName, changes.ToModelName)
 
 	assert.Nil(t, changes.Create)
 	assert.NotEmpty(t, changes.ID)

--- a/service/sync/subject_test.go
+++ b/service/sync/subject_test.go
@@ -49,13 +49,13 @@ func subjectModelDoesNotExist(t *testing.T) {
 	assert.Len(t, changes.Create.Properties, 3)
 
 	assert.NotNil(t, changes.Records)
-	assert.False(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Update)
 	assert.Empty(t, changes.Records.Delete)
 
 	assert.Len(t, changes.Records.Create, 2)
 	// The Create for newSubject
 	{
+		assert.Equal(t, newSubject.ExternalID(), changes.Records.Create[0].ExternalID)
 		values := changes.Records.Create[0].Values
 		// Only contains ID and species because other values are empty
 		assert.Len(t, values, 2)
@@ -74,6 +74,7 @@ func subjectModelDoesNotExist(t *testing.T) {
 
 	// The Create for newSubject2
 	{
+		assert.Equal(t, newSubject2.ExternalID(), changes.Records.Create[1].ExternalID)
 		values := changes.Records.Create[1].Values
 		// Only contains ID and species because other values are empty
 		assert.Len(t, values, 3)
@@ -106,17 +107,17 @@ func subjectModelExistsButNoExistingRecords(t *testing.T) {
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.SubjectModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.False(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Update)
 	assert.Empty(t, changes.Records.Delete)
 
 	assert.Len(t, changes.Records.Create, 2)
 	// The Create for newSubject
 	{
+		assert.Equal(t, newSubject.ExternalID(), changes.Records.Create[0].ExternalID)
 		values := changes.Records.Create[0].Values
 		// Only contains ID and species because other values are empty
 		assert.Len(t, values, 2)
@@ -135,6 +136,7 @@ func subjectModelExistsButNoExistingRecords(t *testing.T) {
 
 	// The Create for newSubject2
 	{
+		assert.Equal(t, newSubject2.ExternalID(), changes.Records.Create[1].ExternalID)
 		values := changes.Records.Create[1].Values
 		// Only contains ID and species because other values are empty
 		assert.Len(t, values, 3)
@@ -213,11 +215,10 @@ func updateSubject(t *testing.T) {
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.SubjectModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.False(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Create)
 	assert.Empty(t, changes.Records.Delete)
 
@@ -279,11 +280,10 @@ func deleteSubject(t *testing.T) {
 	require.NotNil(t, changes)
 
 	expectedModel, _ := schemaData.ModelByName(metadata.SubjectModelName)
-	assert.Equal(t, expectedModel.ID, changes.ID)
+	assert.Equal(t, expectedModel.ID, changes.ID.String())
 	assert.Nil(t, changes.Create)
 
 	assert.NotNil(t, changes.Records)
-	assert.False(t, changes.Records.DeleteAll)
 	assert.Empty(t, changes.Records.Create)
 	assert.Empty(t, changes.Records.Update)
 

--- a/service/sync/sync.go
+++ b/service/sync/sync.go
@@ -5,9 +5,22 @@ import (
 	metadataclient "github.com/pennsieve/processor-pre-metadata/client"
 	"github.com/pennsieve/ttl-sync-processor/client/models/metadata"
 	"github.com/pennsieve/ttl-sync-processor/service/logging"
+	"github.com/pennsieve/ttl-sync-processor/service/mappings/fromrecord"
 )
 
 var logger = logging.PackageLogger("sync")
+
+// ExistingRecordStore is populated by the processor as it maps the existing, raw metadata to the models
+// used for the sync. It will hold a mapping of all existing records of the form
+// (modelName, recordExternalID) -> recordPennsieveID
+// This store will have to be set and reset for tests.
+var ExistingRecordStore *fromrecord.RecordIDStore
+
+// recordIDMap is populated by this package and then passed off to the post-processor file we are creating in this package.
+// Like ExistingRecordStore it is map (modelName, recordExternalID) -> recordPennsieveID, but it will only contain entries
+// for existing records that take part in a link or package proxy "created" by this sync. Since we are only passing the post-processor
+// external IDs, the post-processor will need this map to find the corresponding pennsieve record ids.
+var recordIDMap = make(fromrecord.RecordIDMap)
 
 // ComputeChangeset is the entrypoint for computing the changes necessary to sync the dataset's Pennsieve metadata with that
 // found in the curation export file.
@@ -34,6 +47,9 @@ func ComputeChangeset(schemaData *metadataclient.Schema, old *metadata.SavedData
 		return nil, err
 	}
 	datasetChanges.Proxies = proxyChanges
+
+	appendRecordIDMap(datasetChanges)
+
 	return datasetChanges, nil
 }
 
@@ -65,4 +81,23 @@ func appendLinkedPropertyChanges[OLD metadata.SavedExternalLink, NEW metadata.Ex
 		datasetChanges.LinkedProperties = append(datasetChanges.LinkedProperties, *linkedPropertyChanges)
 	}
 	return nil
+}
+
+func appendRecordIDMap(datasetChanges *changesetmodels.Dataset) {
+	nested := map[string]map[changesetmodels.ExternalInstanceID]changesetmodels.PennsieveInstanceID{}
+	for key, id := range recordIDMap {
+		idMap, found := nested[key.ModelName]
+		if !found {
+			idMap = make(map[changesetmodels.ExternalInstanceID]changesetmodels.PennsieveInstanceID)
+			nested[key.ModelName] = idMap
+		}
+		idMap[key.ExternalRecordID] = id
+	}
+
+	for modelName, idMap := range nested {
+		datasetChanges.RecordIDMaps = append(datasetChanges.RecordIDMaps, changesetmodels.RecordIDMap{
+			ModelName:           modelName,
+			ExternalToPennsieve: idMap,
+		})
+	}
 }

--- a/service/sync/sync_test.go
+++ b/service/sync/sync_test.go
@@ -3,9 +3,11 @@ package sync
 import (
 	"fmt"
 	"github.com/google/uuid"
+	changesetmodels "github.com/pennsieve/processor-post-metadata/client/models"
 	metadataclient "github.com/pennsieve/processor-pre-metadata/client"
 	"github.com/pennsieve/ttl-sync-processor/client/metadatatest"
 	"github.com/pennsieve/ttl-sync-processor/client/models/metadata"
+	"github.com/pennsieve/ttl-sync-processor/service/mappings/fromrecord"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -17,6 +19,9 @@ func TestComputeChangeset(t *testing.T) {
 		"smoke test":                      smokeTest,
 	} {
 		t.Run(scenario, func(t *testing.T) {
+			ExistingRecordStore = fromrecord.NewRecordIDStore()
+			recordIDMap = make(fromrecord.RecordIDMap)
+
 			test(t)
 		})
 	}
@@ -47,10 +52,21 @@ func smokeTest(t *testing.T) {
 		SampleID:  sample.ExternalID(),
 		SubjectID: subject.ExternalID(),
 	}
+	// These are not part of the changeset. But just used to test creating a sample subject
+	// link on records that already exist and are not part of the changeset
+	existingSubject := metadatatest.NewSavedSubject(metadatatest.NewSubjectBuilder().Build())
+	addSavedSubjectRecordID(ExistingRecordStore, existingSubject)
+	existingSample := metadatatest.NewSavedSample(metadatatest.NewSampleBuilder().Build())
+	addSavedSampleRecordID(ExistingRecordStore, existingSample)
+
+	sampleSubjectOnExisting := metadata.SampleSubject{
+		SampleID:  existingSample.ExternalID(),
+		SubjectID: existingSubject.ExternalID(),
+	}
 	proxy := metadata.Proxy{
 		ProxyKey: metadata.ProxyKey{
-			ModelName: metadata.SampleModelName,
-			EntityID:  metadatatest.NewExternalInstanceID(),
+			ModelName:        metadata.SampleModelName,
+			TargetExternalID: metadatatest.NewExternalInstanceID(),
 		},
 		PackageNodeID: fmt.Sprintf("N:collection:%s", uuid.NewString()),
 	}
@@ -61,7 +77,7 @@ func smokeTest(t *testing.T) {
 			Contributors:   []metadata.Contributor{contributor},
 			Subjects:       []metadata.Subject{subject},
 			Samples:        []metadata.Sample{sample},
-			SampleSubjects: []metadata.SampleSubject{sampleSubject},
+			SampleSubjects: []metadata.SampleSubject{sampleSubject, sampleSubjectOnExisting},
 			Proxies:        []metadata.Proxy{proxy},
 		},
 	)
@@ -76,9 +92,23 @@ func smokeTest(t *testing.T) {
 	assert.Len(t, changes.LinkedProperties, 1)
 	sampleSubjectChanges := changes.LinkedProperties[0]
 	assert.NotNil(t, sampleSubjectChanges.ID)
-	assert.Len(t, sampleSubjectChanges.Instances.Create, 1)
+	assert.Len(t, sampleSubjectChanges.Instances.Create, 2)
 
 	assert.NotNil(t, changes.Proxies)
 	assert.False(t, changes.Proxies.CreateProxyRelationshipSchema)
 	assert.Len(t, changes.Proxies.RecordChanges, 1)
+
+	assert.Len(t, changes.RecordIDMaps, 2)
+	assert.Contains(t, changes.RecordIDMaps, changesetmodels.RecordIDMap{
+		ModelName: metadata.SampleModelName,
+		ExternalToPennsieve: map[changesetmodels.ExternalInstanceID]changesetmodels.PennsieveInstanceID{
+			existingSample.ExternalID(): existingSample.GetPennsieveID(),
+		},
+	})
+	assert.Contains(t, changes.RecordIDMaps, changesetmodels.RecordIDMap{
+		ModelName: metadata.SubjectModelName,
+		ExternalToPennsieve: map[changesetmodels.ExternalInstanceID]changesetmodels.PennsieveInstanceID{
+			existingSubject.ExternalID(): existingSubject.GetPennsieveID(),
+		},
+	})
 }


### PR DESCRIPTION
Adding ID and model name maps to the computed changeset file to match changes in the metdata post-processor client.